### PR TITLE
ui fixes

### DIFF
--- a/frontend/src/Components/MapPage.jsx
+++ b/frontend/src/Components/MapPage.jsx
@@ -181,45 +181,56 @@ export default function MapPage() {
             <header className="fm-header">
                 <h6 className="fm-text">PharmaNear</h6>
             </header>
-
             {/* Main Content */}
-            <main className="fm-main">
-                <div className="content-wrapper">
-                    {/* Left Panel */}
-                    <div className="left-panel">
-                        {medicine && <h2 className="medicine-title">Showing results for: {medicine} {dosage && `(${dosage})`}</h2>}
+<main className="fm-main">
+  <div className="content-wrapper">
+    {/* Left Panel */}
+    <div className="left-panel">
+      {medicine && (
+        <h3 className="medicine-title">
+          Showing results for: {medicine} {dosage && `(${dosage})`}
+        </h3>
+      )}
 
-                        {visiblePharmacies.length > 0 ? (
-                            visiblePharmacies.map((pharmacy) => (
-                                <div key={pharmacy.id} className="pharmacy-card">
-                                    <div className="pharmacy-info">
-                                        <h3>{pharmacy.name}</h3>
-                                        <p>{pharmacy.address}</p>
-                                        <p>Closes: {pharmacy.closing}</p>
-                                        <p>{pharmacy.phone}</p>
-                                        {pharmacy.price > 0 && <p>Price: ₹{pharmacy.price}</p>}
-                                        {pharmacy.quantity > 0 && <p>Available: {pharmacy.quantity} units</p>}
-                                        
-                                        {/* Google Maps Button */}
-                                        <button 
-                                            className="google-maps-btn"
-                                            onClick={() => window.open(`https://www.google.com/maps?q=${pharmacy.lat},${pharmacy.lng}`, '_blank')}
-                                            title="Open in Google Maps"
-                                        >
-                                            📍 Open in Google Maps
-                                        </button>
-                                    </div>
-                                    <div className={`stock ${pharmacy.stock}`}>
-                                        {pharmacy.stock === "in-stock" ? "In Stock" : "Out of Stock"}
-                                    </div>
-                                </div>
-                            ))
-                        ) : (
-                            <div className="no-pharmacies-message">
-                                No pharmacies available in this area.
-                            </div>
-                        )}
-                    </div>
+      {/* Scrollable container for pharmacy cards */}
+      <div className="pharmacy-list-scroll">
+        {visiblePharmacies.length > 0 ? (
+          visiblePharmacies.map((pharmacy) => (
+            <div key={pharmacy.id} className="pharmacy-card">
+              <div className="pharmacy-info">
+                <h3>{pharmacy.name}</h3>
+                <p>{pharmacy.address}</p>
+                <p>Closes: {pharmacy.closing}</p>
+                <p>{pharmacy.phone}</p>
+                {pharmacy.price > 0 && <p>Price: ₹{pharmacy.price}</p>}
+                {pharmacy.quantity > 0 && <p>Available: {pharmacy.quantity} units</p>}
+
+                <button
+                  className="google-maps-btn"
+                  onClick={() =>
+                    window.open(
+                      `https://www.google.com/maps?q=${pharmacy.lat},${pharmacy.lng}`,
+                      '_blank'
+                    )
+                  }
+                  title="Open in Google Maps"
+                >
+                  📍 Open in Google Maps
+                </button>
+              </div>
+              <div className={`stock ${pharmacy.stock}`}>
+                {pharmacy.stock === "in-stock" ? "In Stock" : "Out of Stock"}
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="no-pharmacies-message">
+            No pharmacies available in this area.
+          </div>
+        )}
+      </div>
+    </div>
+
 
                     {/* Right Panel - Map */}
                     <div className="right-panel">

--- a/frontend/src/Components/PharmacyAdmin.css
+++ b/frontend/src/Components/PharmacyAdmin.css
@@ -1,6 +1,6 @@
 /* Reset / Base */
 :root {
-  --primary-color: #2f7c6f;
+  --primary-color: #1a9e87;
   --primary-light: #e8f5f3;
   --accent-color: #ff6b6b;
   --accent-hover: #e35757;
@@ -84,6 +84,33 @@ html::-webkit-scrollbar {
   flex-shrink: 0;
 }
 
+.admin-cards-wrapper {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 30px;
+  flex-wrap: nowrap; /* Make responsive if needed */
+}
+
+.profile-card {
+  background: white;
+  padding: 16px;
+  flex: 1;
+  min-width: 280px;
+  border-radius: 12px;
+  box-shadow: 0 3px 15px rgba(26, 158, 135, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+}
+
+.license-address-card input#address {
+  min-height: 3.5em;
+}
+
+
 /* Buttons */
 /* General button */
 .fm-search-btn {
@@ -120,6 +147,32 @@ html::-webkit-scrollbar {
   transform: none;
   box-shadow: none;
 }
+.save-btn {
+  background: linear-gradient(90deg, #12746a 0%, #1a9e87 100%);
+  border-radius: 22px;
+  padding: 16px 42px;
+  font-weight: 700;
+  font-size: 1.1rem;
+  border: 2.5px solid #1a9e87;
+  box-shadow: 0 6px 24px rgba(26,158,135,0.18);
+  letter-spacing: 0.03em;
+  margin: 30px auto 40px auto;
+  display: block;
+  transition: background 0.3s, box-shadow 0.3s, border 0.2s;
+}
+.save-btn:hover:not(:disabled) {
+  background: #1a9e87;
+  border-color: #34b399;
+  box-shadow: 0 8px 38px rgba(26,158,135,0.26);
+}
+.save-btn:disabled {
+  background: #a3c6b8;
+  border-color: #eee;
+  color: #fff;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 
 /* Back to Dashboard button */
 .back-btn {
@@ -349,7 +402,17 @@ html::-webkit-scrollbar {
     flex-direction: column;
     gap: var(--spacing-sm);
   }
-  
+  @media (max-width: 768px) {
+  .admin-cards-wrapper {
+    flex-direction: column; /* Stack vertically */
+    gap: var(--spacing-md);
+  }
+
+  .profile-card {
+    min-width: 100%; /* Full width cards */
+  }
+}
+
   .fm-text {
     font-size: 1.3rem;
   }

--- a/frontend/src/Components/PharmacyAdmin.jsx
+++ b/frontend/src/Components/PharmacyAdmin.jsx
@@ -15,7 +15,7 @@ export default function PharmacyAdmin() {
     latitude: "",
     longitude: "",
   });
-  
+
   // Prevent mouse wheel from changing input values
   useEffect(() => {
     const handleWheel = (e) => {
@@ -23,15 +23,11 @@ export default function PharmacyAdmin() {
         e.preventDefault();
       }
     };
-    
-    // Add event listeners to prevent wheel on all inputs
     const inputs = document.querySelectorAll('input');
     inputs.forEach(input => {
       input.classList.add('no-wheel-input');
       input.addEventListener('wheel', handleWheel, { passive: false });
     });
-    
-    // Clean up event listeners on component unmount
     return () => {
       inputs.forEach(input => {
         input.removeEventListener('wheel', handleWheel);
@@ -39,20 +35,16 @@ export default function PharmacyAdmin() {
     };
   }, []);
 
-
-  // Loading states
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);
 
   useEffect(() => {
     const userName = localStorage.getItem("pharmacy_user_name") || "";
     const token = localStorage.getItem("pharmacy_token") || "";
-    
     if (!userName || !token) {
       navigate('/login');
       return;
     }
-    
     setProfile((p) => ({ ...p, user_name: userName }));
     fetchProfile();
   }, [navigate]);
@@ -64,8 +56,7 @@ export default function PharmacyAdmin() {
       const userName = localStorage.getItem("pharmacy_user_name") || "";
       const token = localStorage.getItem("pharmacy_token") || "";
       const res = await fetch(
-        `http://localhost:5000/api/pharmacy/profile?user_name=${encodeURIComponent(userName)}`,
-        { 
+        `http://localhost:5000/api/pharmacy/profile?user_name=${encodeURIComponent(userName)}`, {
           signal: controller.signal,
           headers: {
             'Authorization': `Bearer ${token}`,
@@ -96,8 +87,6 @@ export default function PharmacyAdmin() {
     }
     return () => controller.abort();
   }
-
-  
 
   async function saveProfile() {
     try {
@@ -155,41 +144,46 @@ export default function PharmacyAdmin() {
     <div className="find-medicine-page">
       {/* Header */}
       <header className="fm-header">
-        <div className="fm-text">Pharmacy Admin Panel</div>
+        <div className="fm-text">PharmaNear</div>
         <div className="fm-location">
-          <h6 style={{ color: 'white', fontSize: '1rem', fontWeight: 'bold', marginBottom: '22px' }}>Welcome, {profile.user_name}</h6>
+          <h6 style={{ color: 'white', fontSize: '1.5rem', fontWeight: 'bold', marginBottom: 22 }}>
+            Welcome, {profile.user_name}
+          </h6>
         </div>
       </header>
+
       <div className="back-to-dashboard-container">
         <button
           type="button"
           className="fm-search-btn back-btn"
           onClick={() => navigate("/pharmacy")}
-          style={{ backgroundColor: '#008060', width: '200px', marginLeft: '-15px' }}
+          style={{ backgroundColor: "white", width: 200, marginLeft: -15, color: '#1a9e87' }}
         >
-          <FaArrowLeft /> Back to Dashboard
+          <FaArrowLeft />Back to Dashboard
         </button>
       </div>
 
       {/* Main Content */}
       <main className="fm-main">
-        <h2 className="fm-title" style={{ marginBottom: '20px', marginTop:'-95px' }}>Pharmacy Management</h2>
+        <h2 className="fm-title" style={{ marginBottom: 20, marginTop: -95 }}>
+          Pharmacy Management
+        </h2>
 
         <div className="fm-grid">
-          {/* Left Column - Profile Settings */}
           <div className="fm-col">
             <div className="admin-section">
               <h3>Pharmacy Profile</h3>
-              <div className="admin-card">
-                <form
-                  className="profile-form"
-                  autoComplete="on"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    saveProfile();
-                  }}
-                >
-                  <div className="fm-input-groups">
+              <form
+                className="profile-form"
+                autoComplete="on"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  saveProfile();
+                }}
+              >
+                <div className="admin-cards-wrapper">
+                  {/* First Card - License Number and Address */}
+                  <div className="admin-card profile-card license-address-card">
                     <label htmlFor="license_number">License Number *</label>
                     <input
                       id="license_number"
@@ -205,9 +199,6 @@ export default function PharmacyAdmin() {
                       }
                       required
                     />
-                  </div>
-
-                  <div className="fm-input-groups">
                     <label htmlFor="address">Address</label>
                     <input
                       id="address"
@@ -218,106 +209,93 @@ export default function PharmacyAdmin() {
                       onChange={(e) =>
                         setProfile((p) => ({ ...p, address: e.target.value }))
                       }
+                      style={{ minHeight: '3.5em' }} // Larger input box
                     />
                   </div>
 
-                  <div className="flexrow" style={{ marginBottom: '40px' }}>
-                    <div className="fm-input-groups">
-                      <label htmlFor="city">City</label>
-                      <input
-                        id="city"
-                        type="text"
-                        className="fm-input"
-                        placeholder="Enter city"
-                        value={profile.city}
-                        onChange={(e) =>
-                          setProfile((p) => ({ ...p, city: e.target.value }))
-                        }
-                      />
-                    </div>
-                    <div className="fm-input-groups" style={{ marginLeft: '20px' }}>
-                      <label htmlFor="state">State</label>
-                      <input
-                        id="state"
-                        type="text"
-                        className="fm-input"
-                        placeholder="Enter state"
-                        value={profile.state}
-                        onChange={(e) =>
-                          setProfile((p) => ({ ...p, state: e.target.value }))
-                        }
-                      />
-                    </div>
-                    <div className="fm-input-groups" style={{ marginLeft: '20px' }}>
-                      <label htmlFor="pincode">Pincode</label>
-                      <input
-                        id="pincode"
-                        type="text"
-                        className="fm-input"
-                        placeholder="Enter postal code"
-                        value={profile.pincode}
-                        onChange={(e) =>
-                          setProfile((p) => ({ ...p, pincode: e.target.value }))
-                        }
-                      />
-                    </div>
+                  {/* Second Card - City, State, Pincode */}
+                  <div className="admin-card profile-card city-state-card">
+                    <label htmlFor="city">City</label>
+                    <input
+                      id="city"
+                      type="text"
+                      className="fm-input"
+                      placeholder="Enter city"
+                      value={profile.city}
+                      onChange={(e) =>
+                        setProfile((p) => ({ ...p, city: e.target.value }))
+                      }
+                    />
+                    <label htmlFor="state">State</label>
+                    <input
+                      id="state"
+                      type="text"
+                      className="fm-input"
+                      placeholder="Enter state"
+                      value={profile.state}
+                      onChange={(e) =>
+                        setProfile((p) => ({ ...p, state: e.target.value }))
+                      }
+                    />
+                    <label htmlFor="pincode">Pincode</label>
+                    <input
+                      id="pincode"
+                      type="text"
+                      className="fm-input"
+                      placeholder="Enter postal code"
+                      value={profile.pincode}
+                      onChange={(e) =>
+                        setProfile((p) => ({ ...p, pincode: e.target.value }))
+                      }
+                    />
                   </div>
 
-                  <div className="flexrow">
-                    <div className="fm-input-groups">
-                      <label htmlFor="latitude">Latitude</label>
-                      <input
-                        id="latitude"
-                        type="number"
-                        step="0.000001"
-                        className="fm-input no-spinner"
-                        placeholder="GPS latitude"
-                        value={profile.latitude}
-                        onChange={(e) =>
-                          setProfile((p) => ({ ...p, latitude: e.target.value }))
-                        }
-                        style={{ overflow: 'hidden' }}
-                      />
-                    </div>
-                    <div className="fm-input-groups">
-                      <label htmlFor="longitude">Longitude</label>
-                      <input
-                        id="longitude"
-                        type="number"
-                        step="0.000001"
-                        className="fm-input no-spinner"
-                        placeholder="GPS longitude"
-                        value={profile.longitude}
-                        onChange={(e) =>
-                          setProfile((p) => ({
-                            ...p,
-                            longitude: e.target.value,
-                          }))
-                        }
-                        style={{ overflow: 'hidden' }}
-                      />
-                    </div>
-                  </div>
-
-                  <button
-                    className="fm-search-btn"
-                    type="submit"
-                    disabled={savingProfile}
-                  >
-                    {savingProfile ? "Saving..." : "Save Profile"}
-                  </button>
-
-                  <div className="location-btn-wrapper">
+                  {/* Third Card - Latitude, Longitude, Use Current Location Button */}
+                  <div className="admin-card profile-card coordinates-card">
+                    <label htmlFor="latitude">Latitude</label>
+                    <input
+                      id="latitude"
+                      type="number"
+                      step="0.000001"
+                      className="fm-input no-spinner"
+                      placeholder="GPS latitude"
+                      value={profile.latitude}
+                      onChange={(e) =>
+                        setProfile((p) => ({ ...p, latitude: e.target.value }))
+                      }
+                      style={{ overflow: 'hidden' }}
+                    />
+                    <label htmlFor="longitude">Longitude</label>
+                    <input
+                      id="longitude"
+                      type="number"
+                      step="0.000001"
+                      className="fm-input no-spinner"
+                      placeholder="GPS longitude"
+                      value={profile.longitude}
+                      onChange={(e) =>
+                        setProfile((p) => ({ ...p, longitude: e.target.value }))
+                      }
+                      style={{ overflow: 'hidden' }}
+                    />
                     <button
                       type="button"
-                      className="fm-search-btn"
+                      className="fm-search-btn location-btn"
                       onClick={fetchCurrentLocation}
                     >
                       <FaMapPin /> Use current location
                     </button>
                   </div>
-                </form>
-              </div>
+                </div>
+
+                <button
+                  className="fm-search-btn save-btn"
+                  type="submit"
+                  disabled={savingProfile}
+                >
+                  {savingProfile ? "Saving..." : "Save Profile"}
+                </button>
+              </form>
             </div>
           </div>
         </div>

--- a/frontend/src/Components/first_page.css
+++ b/frontend/src/Components/first_page.css
@@ -70,7 +70,6 @@
 .fm-input-group {
     margin-bottom: 15px; 
 }
-
 /* Input fields - shared styles */
 .fm-input {
   background-color: var(--input-light-color); 
@@ -84,7 +83,7 @@
 
 /* Search Icon for the first input */
 .fm-input-group > .fm-icon {
-  poposition: absolute;
+  position: absolute;
   left: 15px;
   top: 50%;
   transform: translateY(-50%);

--- a/frontend/src/Components/mappage.css
+++ b/frontend/src/Components/mappage.css
@@ -18,6 +18,7 @@ body {
 .find-medicine-page {
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     min-height: 100vh;
     background-color: #ffffff;
 }
@@ -29,7 +30,7 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 8px 20px;
-    background-color: #1b806d;
+    background-color: #1a9e87;
     color: white;
     gap: 15px;
     flex-wrap: wrap;
@@ -183,6 +184,12 @@ body {
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     height: 100%;
 }
+.pharmacy-list-scroll {
+  flex-grow: 1;
+  overflow-y: auto; /* Scroll only this box */
+  padding-right: 6px; /* Optional scrollbar padding */
+  max-height: 100%;
+}
 
 /* Make the search-sort-container responsive */
 .search-sort-container {
@@ -250,8 +257,8 @@ body {
 /* Stock Indicator */
 .stock {
     position: absolute;
-    top: 15px;
-    right: 50px;
+    top: 10px;
+    right: 10px;
     padding: 5px 10px;
     border-radius: 15px;
     text-transform: uppercase;
@@ -346,7 +353,7 @@ body {
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    background-color: var(--teal-color); 
+    background-color: #1a9e87; 
     padding: 15px 30px;
     width: 100%;
     flex-wrap: nowrap;
@@ -356,7 +363,7 @@ body {
 }
 
 .fm-footer-content {
-    display: none;
+    display:flex;
     padding: 0;
     gap: 40px;
     align-items: center;

--- a/frontend/src/Components/pharmacy_dashboard.css
+++ b/frontend/src/Components/pharmacy_dashboard.css
@@ -1,5 +1,5 @@
 :root {
-    --primary-color: #008060; 
+    --primary-color: #1a9e87; 
     --primary-hover-color: #00664c;
     --secondary-color: #e5e7eb;
     --danger-color: #dc2626;
@@ -49,6 +49,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    height: 75px;
 }
 
 .logo {
@@ -310,6 +311,32 @@ body {
     padding: 0.5rem 1rem;
     border-radius: var(--border-radius);
     cursor: pointer;
+}
+.fm-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--teal-color); 
+  padding: 15px 30px;
+  width: 100%;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  position: static; 
+  margin-top: auto; 
+}
+
+.fm-footer-links {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: center;
+    gap: 30px; 
+}
+
+.fm-footer a {
+  text-decoration: none;
+  color: white;
+  font-size: 0.85rem;
 }
 
 @media (min-width: 768px) {

--- a/frontend/src/Components/pharmacy_dashboard.jsx
+++ b/frontend/src/Components/pharmacy_dashboard.jsx
@@ -38,7 +38,7 @@ const SearchIcon = () => (
 // Header component 
 const Header = () => (
   <header className="header">
-    <h1 className="logo">FindMeds</h1>
+    <h1 className="logo">PharmaNear</h1>
     <button className="logout">Logout</button>
   </header>
 );
@@ -172,6 +172,14 @@ export default function PharmacyDashboard() {
       </main>
 
       <MedicineModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} onSave={handleSave} medicine={editingMedicine} />
+        <footer className="fm-footer">
+  <a href="#">About Us</a>
+  <a href="#">Services</a>
+  <a href="#">Contact</a>
+  <a href="#">Privacy Policy</a>
+  <a href="#">Terms of Service</a>
+</footer>
+
     </div>
   );
 }

--- a/frontend/src/Components/pharmacy_page.css
+++ b/frontend/src/Components/pharmacy_page.css
@@ -21,7 +21,6 @@
   box-sizing: border-box;
 }
 
-
 .medicine-page
 {
   display: flex;
@@ -35,25 +34,23 @@
   margin: 0;
 }
 
-
 .fm-header {
+  flex-shrink: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 10vh;
-  background-color: #14967f;  
+  height: 60px;
+  background-color: #1a9e87;  
   color: white;
   padding: 0 20px;
 }
-
 
 .fm-header .fm-text 
 {
   font-size: 1.5rem;
   font-weight: bold;
-  margin-top: 17px;
+  margin-top: 2px;
 }
-
 
 .fm-location
 {
@@ -76,7 +73,6 @@
   background-color: var(--primary-hover-color) !important;
 }
 
-
 .fm-location-button {
   background: transparent;
   font-family:'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
@@ -93,7 +89,6 @@
   outline:none;
 }
 
-
 .dropdown-arrow 
 {
   margin-left: 4px;
@@ -101,65 +96,162 @@
   color: white;
 }
 
-
-.fm-main
-{
+.pharmacy-main {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  padding-top: 100px;
-  background-color: white;
-  padding-left: 10px;
-  padding-right: 10px;
+  align-items: stretch;
+  padding: 32px 16px 0 16px;
   box-sizing: border-box;
-  width: 100%;
 }
 
-
-.fm-title 
-{
-  font-size: 2.5rem;
-  font-weight: bold;
-  margin-bottom: 30px;
-  color: #333;
-  text-align: center;
-  max-width: 100%;
-}
-
-/* Admin panel helpers */
-.admin-section
-{
-  width: 100%;
-  max-width: 800px;
-  margin-bottom: 32px;
-}
-
-.admin-card
-{
-  background: #fff;
-  padding: 16px;
-  border-radius: 8px;
-  border: 1px solid #e2e8f0;
-}
-
-.admin-actions
-{
+.pharmacy-main-top {
   display: flex;
-  gap: 12px;
+  flex-direction: row;
+  gap: 32px;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+}
+
+.pharmacy-summary-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 220px;
+  flex: 0 0 220px;
+}
+
+.pharmacy-summary-card {
+  background: var(--primary-color);
+  color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.10);
+  padding: 28px 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
   align-items: center;
 }
 
-.fm-label
-{
-  display: block;
-  font-weight: 600;
-  font-size: 12px;
+.summary-value {
+  font-size: 2.2rem;
+  font-weight: bold;
   margin-bottom: 6px;
 }
 
+.summary-label {
+  font-size: 1rem;
+  opacity: 0.92;
+}
 
+.pharmacy-add-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.13);
+  padding: 32px 28px 28px 28px;
+  min-width: 340px;
+  max-width: 900px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.pharmacy-welcome {
+  color: #00664c;
+  font-weight: bold;
+  font-size: 2rem;
+  margin-bottom: 18px;
+  text-align: center;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+}
+
+.pharmacy-add-title {
+  color: #14967f;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 18px;
+  text-align: center;
+}
+
+.pharmacy-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pharmacy-error {
+  color: #dc2626;
+  background: #fee2e2;
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-top: 12px;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.pharmacy-table-section {
+  width: 100%;
+  max-width: 1200px;
+  margin-top: 40px;
+}
+
+/* Responsive styles */
+@media (max-width: 900px) {
+  .pharmacy-main-top {
+    flex-direction: column;
+    gap: 24px;
+    align-items: stretch;
+  }
+  .pharmacy-summary-cards {
+    flex-direction: row;
+    gap: 16px;
+    min-width: unset;
+    justify-content: center;
+  }
+  .pharmacy-summary-card {
+    min-width: 120px;
+    padding: 18px 10px;
+    font-size: 1rem;
+  }
+  .pharmacy-add-card {
+    min-width: unset;
+    max-width: 100%;
+    padding: 20px 10px 18px 10px;
+  }
+  .pharmacy-table-section {
+    margin-top: 24px;
+  }
+}
+
+@media (max-width: 600px) {
+  .pharmacy-main {
+    padding: 16px 2px 0 2px;
+  }
+  .pharmacy-add-card {
+    padding: 12px 4px 10px 4px;
+  }
+  .pharmacy-welcome {
+    font-size: 1.2rem;
+  }
+  .pharmacy-add-title {
+    font-size: 1rem;
+  }
+  .pharmacy-summary-cards {
+    flex-direction: column;
+    gap: 10px;
+  }
+  .pharmacy-summary-card {
+    padding: 10px 4px;
+    font-size: 0.9rem;
+  }
+}
+
+/* Existing styles for inputs, buttons, footer, etc. */
 .fm-input-group,
 .fm-input-groups 
 {
@@ -171,24 +263,10 @@
   gap: 10px;
 }
 
-
-.flexrow 
-{
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  width: 100%;
-  max-width: 800px;
-  gap: 20px;
-  box-sizing: border-box;
-}
-
-
 .fm-input-groups 
 {
   flex-grow: 1;
 }
-
 
 .fm-input 
 {
@@ -202,7 +280,6 @@
   box-sizing: border-box;
 }
 
-
 .fm-input:hover 
 {
   background-color: #dee8ec;
@@ -210,12 +287,10 @@
   transition: background-color 0.2s, border-color 0.2s;
 }
 
-
 .fm-input::placeholder 
 {
   color: #415055;
 }
-
 
 .fm-search-btn 
 {
@@ -233,37 +308,19 @@
   box-sizing: border-box;
 }
 
-
 .fm-search-btn:disabled 
 {
   cursor: not-allowed;
 }
 
-.fm-register {
-  margin-top: 12px;
-  font-size: 0.9rem;
-  color: #415055;
-  text-align: center;
-}
-
-.fm-register a {
-  margin-left: 6px;
-  color: #14967f;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.fm-register a:hover {
-  text-decoration: underline;
-}
-
 .fm-footer {
+  flex-shrink: 0;
   display: flex;
-  justify-content: space-between; 
+  justify-content: center; 
   align-items: center;
   min-height: 60px;
   padding: 16px 40px;
-  background-color: #14967f; 
+  background-color: #1a9e87; 
   box-sizing: border-box;
   width: 100%;
 }
@@ -289,7 +346,6 @@
   position: relative;
 }
 
-
 .fm-icon 
 {
   position: absolute;
@@ -300,45 +356,13 @@
   font-size: 1.2rem;
 }
 
-
 .with-icon 
 {
   padding-left: 40px;
 }
 
-
 @media (max-width: 900px) 
 {
-  .flexrow 
-  {
-    flex-direction: column;
-    width: 100%;
-    max-width: 100%;
-    gap: 12px;
-  }
-
-  .fm-input-group,
-  .fm-input-groups,
-  .fm-search-btn 
-  {
-    width: 100%;
-    max-width: 100%;
-  }
-
-  .fm-main 
-  {
-    padding-top: 50px;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 100px;
-  }
-
-  .fm-title 
-  {
-    font-size: 1.8rem;
-    margin-bottom: 20px;
-  }
-
   .fm-footer 
   {
     gap: 16px;
@@ -351,44 +375,6 @@
 
 @media (max-width: 600px) 
 {
-  .fm-header 
-  {
-    height: auto;
-    min-height: 10vh;
-    padding: 10px 15px;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .fm-text 
-  {
-    font-size: 1.2rem;
-    text-align: center;
-    width: 100%;
-  }
-
-  .fm-title 
-  {
-    font-size: 1.5rem;
-  }
-
-  .admin-card 
-  {
-    padding: 12px;
-  }
-
-  .fm-input 
-  {
-    padding: 10px;
-    font-size: 0.9rem;
-  }
-
-  .fm-search-btn 
-  {
-    padding: 10px 16px;
-    font-size: 1rem;
-  }
-
   .fm-footer 
   {
     flex-direction: column;
@@ -409,14 +395,12 @@
   overflow-x: hidden;
 }
 
-/* Ensure all form elements are properly contained */
 .fm-input-group,
 .fm-input-groups {
   box-sizing: border-box;
   overflow-x: hidden;
 }
 
-/* Prevent text overflow */
 .fm-text,
 .fm-title,
 .fm-footer a {

--- a/frontend/src/components/login_page.css
+++ b/frontend/src/components/login_page.css
@@ -2,7 +2,7 @@
 /* Layout */
 .login-layout {
   display: grid;
-  grid-template-columns: 3fr 7fr;
+  grid-template-columns: 2fr 5fr;
   min-height: 100vh;
   border:none;
   border-radius: 10px;
@@ -17,16 +17,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 48px 24px;
+  padding: 40px 20px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.6));
   border:none;
+  min-height: 100vh;
+  box-sizing: border-box;
   border-radius: 0 16px 16px 0;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .login-card {
   width: 100%;
   max-width: 520px;
+  
 }
 
 .login-title {
@@ -34,7 +37,7 @@
   line-height: 1.1;
   letter-spacing: 2px;
   text-align: center;
-  margin: 0 0 28px 0;
+  margin: 0 0 2px 0;
   font-family: Poppins;
   font-weight: 600;
   color: #2f7c6f;
@@ -50,6 +53,7 @@
 .input-group {
   position: relative;
   margin-top: 1.5rem;
+  margin-bottom: 0.25px;
 }
 
 .input-group input {


### PR DESCRIPTION
Fixed same colour for header and footer in all pages

Mappage:
Added footer links
Mappage made static and introduced a scroll down only for the cards which display stocks and shops
Decreased the size of "Showing results for:"
Adjusted the position of instock outofstock button

Pharmacy page:
Header and footer made same
Redesigned the pharmacy page

Pharmacy admin page:
Split the current central card with all inputs into three distinct cards horizontally side by side.
Card 1: License Number and Address inputs (Address input box is larger).
Card 2: City, State, Pincode inputs. Remove any scroll within this.
Card 3: Latitude, Longitude inputs and the "Use current location" button.
Kept the "Save Profile" button below these three cards in the same place as before.
Made sure the page does not scroll vertically; the cards fit horizontally and visually balanced.
Used the teal-green palette consistent with the rest of the app.

Pharmacy dashboard page:
Added footer

Signup page:
Adjusted the right section