### PR TITLE
fix(security): prevent IDOR on stock endpoints by using req.user.id

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -344,7 +344,10 @@ app.put("/api/pharmacy/profile", AuthMiddleware, async (req, res) => {
 // Add medicine stock for a pharmacy if medicine not exist it adds the medicine to the database and then adds to the stock
 app.post("/api/pharmacy/stock", AuthMiddleware, async (req, res) => {
   try {
-    const { pharmacy_id, medicine_name, quantity, price, strength } = req.body;
+    const { medicine_name, quantity, price, strength } = req.body;
+
+    // Use authenticated user's ID to prevent IDOR vulnerability
+    const pharmacy_id = req.user.id;
 
     // Validation
     if (!pharmacy_id)
@@ -494,8 +497,16 @@ app.get("/api/drugs", async (req, res) => {
 
 app.patch("/api/pharmacy/stock", AuthMiddleware, async (req, res) => {
   try {
-    const { pharmacy_id, medicine_name, quantity, price } = req.body;
+    const { medicine_name, quantity, price } = req.body;
     console.log("Request body:", req.body);
+
+    // Use authenticated user's ID to prevent IDOR vulnerability
+    const pharmacy_id = req.user.id;
+
+    // Block attempts to modify another pharmacy's stock
+    if (req.body.pharmacy_id && req.body.pharmacy_id !== req.user.id) {
+      return res.status(403).json({ message: "Forbidden: You can only modify your own pharmacy's stock" });
+    }
 
     if (!pharmacy_id || !medicine_name || !quantity || !price) {
       return res.status(400).json({ message: "Invalid stock data" });
@@ -533,7 +544,16 @@ app.patch("/api/pharmacy/stock", AuthMiddleware, async (req, res) => {
 
 app.delete("/api/pharmacy/stock", AuthMiddleware, async (req, res) => {
   try {
-    const { pharmacy_id, medicine_name } = req.body;
+    const { medicine_name } = req.body;
+
+    // Use authenticated user's ID to prevent IDOR vulnerability
+    const pharmacy_id = req.user.id;
+
+    // Block attempts to delete another pharmacy's stock
+    if (req.body.pharmacy_id && req.body.pharmacy_id !== req.user.id) {
+      return res.status(403).json({ message: "Forbidden: You can only modify your own pharmacy's stock" });
+    }
+
     if (!pharmacy_id || !medicine_name) {
       return res.status(400).json({ message: "Invalid stock data" });
     }


### PR DESCRIPTION
## 🔗 Linked Issues
Closes #22 


## 📝 Changes Made

- Replaced req.body.pharmacy_id with req.user.id in POST /api/pharmacy/stock to prevent IDOR vulnerability
- Replaced req.body.pharmacy_id with req.user.id in PATCH /api/pharmacy/stock and added a 403 Forbidden check if a different pharmacy_id is supplied in the request body
- Replaced req.body.pharmacy_id with req.user.id in DELETE /api/pharmacy/stock and added a 403 Forbidden check if a different pharmacy_id is supplied in the request body
- All stock modifications are now restricted to the authenticated pharmacy's own records via AuthMiddleware 


## 📸 Screenshots
N/A

## ✅ Testing Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] I have tested these changes locally.
- [ ] I have run `pnpm run test` and all tests pass.
- [x] I have added/updated necessary documentation.
- [x] My commit messages follow the Conventional Commits format.
