### PR TITLE
feat(frontend): add NotFoundPage for 404 errors

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import PharmacyPage from './components/PharmacyPage.jsx';
 import PharmacyDashboard from './components/PharmacyDashboard.jsx';
 import LoginPage from './components/LoginPage.jsx';
 import SignupPage from './components/SignupPage.jsx';
+import NotFoundPage from './components/NotFoundPage.jsx';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
         <Route path="/pharmacy/dashboard" element={<PharmacyDashboard />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/NotFoundPage.css
+++ b/frontend/src/components/NotFoundPage.css
@@ -1,0 +1,154 @@
+.not-found-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  width: 100%;
+  background: linear-gradient(135deg, #f3fbf9 0%, #e2f5f1 100%);
+  font-family: 'Outfit', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.not-found-card {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(26, 158, 135, 0.15);
+  border-radius: 24px;
+  padding: 50px 40px;
+  text-align: center;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: 0 20px 40px rgba(26, 158, 135, 0.08), 
+              0 1px 3px rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: fadeIn 0.6s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animated-icon-container {
+  position: relative;
+  width: 200px;
+  height: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.error-code {
+  font-size: 5.5rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #1a9e87 0%, #0d6d5c 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1;
+  letter-spacing: -2px;
+  user-select: none;
+}
+
+.floating-capsule {
+  position: absolute;
+  font-size: 2.2rem;
+  color: #1a9e87;
+  opacity: 0.8;
+}
+
+.floating-capsule.c1 {
+  top: 10px;
+  left: 20px;
+  animation: float1 4s ease-in-out infinite;
+  transform: rotate(-15deg);
+}
+
+.floating-capsule.c2 {
+  bottom: 10px;
+  right: 20px;
+  animation: float2 4.5s ease-in-out infinite;
+  transform: rotate(45deg);
+}
+
+@keyframes float1 {
+  0%, 100% {
+    transform: translateY(0) rotate(-15deg);
+  }
+  50% {
+    transform: translateY(-12px) rotate(10deg);
+  }
+}
+
+@keyframes float2 {
+  0%, 100% {
+    transform: translateY(0) rotate(45deg);
+  }
+  50% {
+    transform: translateY(-15px) rotate(20deg);
+  }
+}
+
+.not-found-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1b2e2b;
+  margin: 10px 0 15px;
+  line-height: 1.2;
+}
+
+.not-found-text {
+  font-size: 1.05rem;
+  color: #566c68;
+  line-height: 1.6;
+  margin-bottom: 25px;
+}
+
+.home-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #1a9e87;
+  color: #ffffff;
+  padding: 14px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 12px;
+  text-decoration: none;
+  box-shadow: 0 4px 14px rgba(26, 158, 135, 0.3);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.home-button:hover {
+  background-color: #14806d;
+  color: #ffffff !important;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(26, 158, 135, 0.4);
+}
+
+.home-button:active {
+  transform: translateY(0);
+}
+
+.home-icon {
+  font-size: 1.1rem;
+}
+
+@media (max-width: 480px) {
+  .not-found-card {
+    padding: 40px 20px;
+  }
+  .not-found-title {
+    font-size: 1.7rem;
+  }
+}

--- a/frontend/src/components/NotFoundPage.jsx
+++ b/frontend/src/components/NotFoundPage.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaHome, FaCapsules, FaSearch } from "react-icons/fa";
+import "./NotFoundPage.css";
+
+function NotFoundPage() {
+  return (
+    <div className="not-found-container">
+      <div className="not-found-card">
+        <div className="animated-icon-container">
+          <FaCapsules className="floating-capsule c1" />
+          <FaCapsules className="floating-capsule c2" />
+          <div className="error-code">404</div>
+        </div>
+        <h1 className="not-found-title">Lost in the Pharmacy?</h1>
+        <p className="not-found-text">
+          We couldn't find the page you were looking for. 
+        </p>
+        <Link to="/" className="home-button">
+          <FaHome className="home-icon" />
+          Return to Homepage
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/frontend/src/components/NotFoundPage.jsx
+++ b/frontend/src/components/NotFoundPage.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { FaHome, FaCapsules, FaSearch } from "react-icons/fa";
+import { FaHome, FaCapsules } from "react-icons/fa";
 import "./NotFoundPage.css";
 
 function NotFoundPage() {


### PR DESCRIPTION
## 🔗 Linked Issues
Closes #29

## 📝 Changes Made
- Added a custom 404 Not Found page with a clean, user-friendly design and a button to navigate back to the home page.
- Updated the app routing by adding a catch-all (`*`) route to display the custom 404 page for unknown URLs.

## 📸 Screenshots
<img width="1920" height="994" alt="image" src="https://github.com/user-attachments/assets/2f34b7f3-5f70-46b6-bd89-223531becffc" />


## 📚 Documentation Changes
- [x] No documentation changes needed

## ⚙️ Environment Variables
- [x] No new environment variables needed


## ✅ Testing Checklist
- [x] I have read the `CONTRIBUTING.md` guide.
- [x] I am assigned to the linked issue(s).
- [x] I have tested these changes locally.
- [x] I have run `pnpm run test` and all tests pass.
- [x] My code uses standard LF (Unix-style) line endings.
- [x] My commit messages follow the Conventional Commits format.