### PR TITLE
refactor(frontend): move pharmacy page styles to CSS

### DIFF
--- a/frontend/src/components/PharmacyPage.css
+++ b/frontend/src/components/PharmacyPage.css
@@ -252,29 +252,238 @@
 }
 
 /* New styles for pharmacy table rows */
-.pharmacy-table-row {
+.pharmacy-table-shell {
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  margin-bottom: 200px;
+}
+
+.pharmacy-table-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  padding: 16px 20px;
+  background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #4a5568;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+.pharmacy-table-header-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px;
+  gap: 8px;
+}
+
+.pharmacy-table-header-actions {
+  text-align: right;
+}
+
+.pharmacy-table-header-icon {
+  color: #00664c;
+}
+
+.pharmacy-table-loading,
+.pharmacy-table-empty {
+  padding: 40px;
+  text-align: center;
+  color: #718096;
+  font-size: 1.1rem;
+}
+
+.pharmacy-table-spinner {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border: 3px solid #e2e8f0;
+  border-top: 3px solid #667eea;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+.pharmacy-table-empty-icon {
+  font-size: 2rem;
+  margin-bottom: 10px;
+  opacity: 0.5;
+}
+
+.pharmacy-table-empty-caption {
+  font-size: 0.9rem;
+  margin-top: 5px;
+  opacity: 0.8;
+}
+
+.pharmacy-table-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  padding: 16px 20px;
+  border-top: 1px solid #f1f5f9;
   background-color: white;
+  transition: all 0.2s ease;
+  align-items: center;
+}
+
+.pharmacy-table-row:first-of-type {
+  border-top: none;
+}
+
+.pharmacy-table-row-editing {
+  background-color: #f0fdf4;
+}
+
+.pharmacy-table-row:nth-of-type(odd):not(.pharmacy-table-row-editing) {
+  background-color: #fafbfc;
+}
+
+.pharmacy-table-row-mobile {
+  display: block;
+  padding: 16px;
+  margin-bottom: 8px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  transition: box-shadow 0.2s;
-  margin-bottom: 12px; /* This adds the vertical gap */
 }
 
-.pharmacy-table-row:hover {
-  box-shadow: 0 4px 8px rgba(0,0,0,0.08);
+.pharmacy-table-row-mobile:last-child {
+  margin-bottom: 0;
 }
 
-/* This is the container for the inline edit form */
+.pharmacy-table-cell {
+  color: #00664c;
+  font-weight: 600;
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.pharmacy-table-cell-name {
+  font-weight: 600;
+  color: #00664c;
+  font-size: 0.95rem;
+}
+
+.pharmacy-table-mobile-title {
+  font-weight: 600;
+  color: #00664c;
+  font-size: 1rem;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pharmacy-table-mobile-icon {
+  color: #667eea;
+}
+
+.pharmacy-table-mobile-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.pharmacy-table-mobile-meta {
+  color: #00664c;
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pharmacy-table-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.pharmacy-table-action-button {
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: all 0.2s ease;
+}
+
+.pharmacy-table-action-button-edit {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
+.pharmacy-table-action-button-edit:hover {
+  background-color: #bfdbfe;
+}
+
+.pharmacy-table-action-button-delete {
+  background-color: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+}
+
+.pharmacy-table-action-button-delete:hover {
+  background-color: #fecaca;
+}
+
 .edit-form-container {
-  display: contents; /* This makes it work with the parent grid */
+  display: contents;
 }
 
-.edit-form-container > div {
-  padding: 0 5px; /* Adds a small horizontal gap for desktop */
+.pharmacy-table-edit-grid {
+  display: contents;
+  grid-column: 1 / -1;
+}
+
+.pharmacy-edit-field {
+  display: flex;
+  align-items: center;
+}
+
+.pharmacy-edit-input {
+  margin: 0;
+  font-size: 0.9rem;
+  border: 2px solid #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.1);
+}
+
+.pharmacy-table-edit-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
+  grid-column: 4;
+}
+
+.pharmacy-table-save-button {
+  padding: 8px 16px;
+  font-size: 0.8rem;
+  background-color: #10b981;
+  min-height: auto;
+  width: auto;
+}
+
+.pharmacy-table-cancel-button {
+  padding: 8px 16px;
+  font-size: 0.8rem;
+  background-color: #f8fafc;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.pharmacy-input-icon {
+  color: #14967f;
+}
+
+.pharmacy-add-button-icon {
+  margin-right: 8px;
 }
 
 .medicine-details {

--- a/frontend/src/components/PharmacyPage.css
+++ b/frontend/src/components/PharmacyPage.css
@@ -272,6 +272,10 @@
   border-bottom: 2px solid #e2e8f0;
 }
 
+.pharmacy-table-header-mobile {
+  display: none;
+}
+
 .pharmacy-table-header-item {
   display: flex;
   align-items: center;
@@ -432,12 +436,18 @@
 }
 
 .edit-form-container {
-  display: contents;
+  display: block;
+  width: 100%;
 }
 
 .pharmacy-table-edit-grid {
-  display: contents;
+  display: grid;
   grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 6px 0;
 }
 
 .pharmacy-edit-field {
@@ -458,17 +468,26 @@
   justify-content: flex-end;
   align-items: center;
   grid-column: 4;
+  flex-wrap: wrap;
 }
 
 .pharmacy-table-save-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   padding: 8px 16px;
   font-size: 0.8rem;
   background-color: #10b981;
   min-height: auto;
   width: auto;
+  margin-top: 0;
 }
 
 .pharmacy-table-cancel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 8px 16px;
   font-size: 0.8rem;
   background-color: #f8fafc;
@@ -653,22 +672,30 @@
     border-radius: 8px; /* Smaller border radius on mobile */
   }
   
-  /* This will stack the edit form inputs vertically on mobile */
   .edit-form-container {
-    display: flex; /* Switch to flex for mobile stacking */
+    display: flex;
     flex-direction: column;
-    align-items: stretch; /* Make inputs full width */
-    gap: 10px; /* This adds the vertical gap for mobile */
+    align-items: stretch;
+    gap: 10px;
     width: 100%;
   }
 
-  /* Target the button container specifically on mobile */
-  .edit-form-container > div:last-child {
+  .pharmacy-table-edit-grid {
+    display: flex;
     flex-direction: column;
+    gap: 10px;
+    width: 100%;
   }
 
-  .edit-form-container > div {
-    padding: 0; /* Reset padding for mobile */
+  .pharmacy-table-edit-actions {
+    justify-content: stretch;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .pharmacy-table-save-button,
+  .pharmacy-table-cancel-button {
+    width: 100%;
   }
 }
 

--- a/frontend/src/components/PharmacyPage.jsx
+++ b/frontend/src/components/PharmacyPage.jsx
@@ -430,7 +430,7 @@ export default function PharmacyPage() {
                 </div>
               </div>
             ) : (
-              stockItems.map((item, index) => (
+              stockItems.map((item) => (
                 <div
                   key={item.id}
                   className={`pharmacy-table-row ${isMobile ? "pharmacy-table-row-mobile" : "pharmacy-table-row-desktop"} ${editingItem?.id === item.id ? "pharmacy-table-row-editing" : ""}`}

--- a/frontend/src/components/PharmacyPage.jsx
+++ b/frontend/src/components/PharmacyPage.jsx
@@ -433,7 +433,7 @@ export default function PharmacyPage() {
               stockItems.map((item) => (
                 <div
                   key={item.id}
-                  className={`pharmacy-table-row ${isMobile ? "pharmacy-table-row-mobile" : "pharmacy-table-row-desktop"} ${editingItem?.id === item.id ? "pharmacy-table-row-editing" : ""}`}
+                  className={`pharmacy-table-row ${isMobile ? "pharmacy-table-row-mobile" : ""} ${editingItem?.id === item.id ? "pharmacy-table-row-editing" : ""}`}
                 >
                   {editingItem?.id === item.id ? (
                     <div className="edit-form-container pharmacy-table-edit-grid">

--- a/frontend/src/components/PharmacyPage.jsx
+++ b/frontend/src/components/PharmacyPage.jsx
@@ -344,7 +344,7 @@ export default function PharmacyPage() {
             <h3 className="pharmacy-add-title">Add Medicine To Stock</h3>
             <form onSubmit={handleAdd} className="pharmacy-add-form">
               <div className="fm-input-groups relative">
-                <FaCapsules className="fm-icon" style={{ color: "#14967f" }} />
+                <FaCapsules className="fm-icon pharmacy-input-icon" />
                 <input
                   type="text"
                   placeholder="Medicine Name"
@@ -355,7 +355,7 @@ export default function PharmacyPage() {
                 />
               </div>
               <div className="fm-input-groups relative">
-                <FaSortNumericUp className="fm-icon" style={{ color: "#14967f" }} />
+                <FaSortNumericUp className="fm-icon pharmacy-input-icon" />
                 <input
                   type="number"
                   placeholder="Quantity"
@@ -367,7 +367,7 @@ export default function PharmacyPage() {
                 />
               </div>
               <div className="fm-input-groups relative">
-                <FaDollarSign className="fm-icon" style={{ color: "#14967f" }} />
+                <FaDollarSign className="fm-icon pharmacy-input-icon" />
                 <input
                   type="number"
                   step="0.01"
@@ -380,7 +380,7 @@ export default function PharmacyPage() {
                 />
               </div>
               <div className="fm-input-groups relative">
-                <FaCapsules className="fm-icon" style={{ color: "#14967f" }} />
+                <FaCapsules className="fm-icon pharmacy-input-icon" />
                 <input
                   type="text"
                   placeholder="Strength (optional, e.g., 500mg)"
@@ -390,7 +390,7 @@ export default function PharmacyPage() {
                 />
               </div>
               <button className="fm-search-btn" type="submit">
-                <FaPlus style={{ marginRight: 8 }} /> Add To Stock
+                <FaPlus className="pharmacy-add-button-icon" /> Add To Stock
               </button>
             </form>
             {error && <div className="pharmacy-error">{error}</div>}
@@ -398,166 +398,85 @@ export default function PharmacyPage() {
         </div>
         {/* Table below both sections */}
         <div className="pharmacy-table-section">
-          <div style={{ 
-            background: "#fff", 
-            borderRadius: "12px", 
-            overflow: "hidden", 
-            border: "1px solid #e2e8f0",
-            boxShadow: "0 4px 6px rgba(0, 0, 0, 0.05)",
-            marginBottom: "200px"
-          }}>
+          <div className="pharmacy-table-shell">
             {/* Table Header */}
-            <div style={{ 
-              display: isMobile ? "none" : "grid", 
-              gridTemplateColumns: "2fr 1fr 1fr 1fr", 
-              padding: "16px 20px", 
-              background: "linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%)",
-              fontWeight: 600,
-              fontSize: "0.9rem",
-              color: "#4a5568",
-              borderBottom: "2px solid #e2e8f0"
-            }}>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                <FaCapsules style={{ color: "#00664c" }} />
+            <div className={`pharmacy-table-header ${isMobile ? "pharmacy-table-header-mobile" : ""}`}>
+              <div className="pharmacy-table-header-item">
+                <FaCapsules className="pharmacy-table-header-icon" />
                 Medicine Name
               </div>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                <FaSortNumericUp style={{ color: "#00664c" }} />
+              <div className="pharmacy-table-header-item">
+                <FaSortNumericUp className="pharmacy-table-header-icon" />
                 Quantity
               </div>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                <FaDollarSign style={{ color: "#00664c" }} />
+              <div className="pharmacy-table-header-item">
+                <FaDollarSign className="pharmacy-table-header-icon" />
                 Price (₹)
               </div>
-              <div style={{ textAlign: 'right' }}>Actions</div>
+              <div className="pharmacy-table-header-actions">Actions</div>
             </div>
             {/* Table Body */}
             {loading ? (
-              <div style={{ 
-                padding: "40px", 
-                textAlign: "center", 
-                color: "#718096",
-                fontSize: "1.1rem"
-              }}>
-                <div style={{ 
-                  display: "inline-block", 
-                  width: "24px", 
-                  height: "24px", 
-                  border: "3px solid #e2e8f0",
-                  borderTop: "3px solid #667eea",
-                  borderRadius: "50%",
-                  animation: "spin 1s linear infinite",
-                  marginBottom: "10px"
-                }}></div>
+              <div className="pharmacy-table-loading">
+                <div className="pharmacy-table-spinner"></div>
                 <div>Loading stock data...</div>
               </div>
             ) : stockItems.length === 0 ? (
-              <div style={{ 
-                padding: "40px", 
-                textAlign: "center", 
-                color: "#718096",
-                fontSize: "1.1rem"
-              }}>
-                <FaCapsules style={{ fontSize: "2rem", marginBottom: "10px", opacity: 0.5 }} />
+              <div className="pharmacy-table-empty">
+                <FaCapsules className="pharmacy-table-empty-icon" />
                 <div>No medicines in stock yet.</div>
-                <div style={{ fontSize: "0.9rem", marginTop: "5px", opacity: 0.8 }}>
+                <div className="pharmacy-table-empty-caption">
                   Add medicines using the form above to get started.
                 </div>
               </div>
             ) : (
               stockItems.map((item, index) => (
-                <div key={item.id} style={{ 
-                  display: isMobile ? "block" : "grid", 
-                  gridTemplateColumns: isMobile ? "none" : "2fr 1fr 1fr 1fr", 
-                  padding: isMobile ? "16px" : "16px 20px", 
-                  borderTop: index > 0 ? "1px solid #f1f5f9" : "none",
-                  backgroundColor: editingItem?.id === item.id ? '#f0fdf4' : (index % 2 === 0 ? '#fafbfc' : 'white'),
-                  transition: "all 0.2s ease",
-                  alignItems: "center",
-                  marginBottom: isMobile ? "8px" : "0"
-                }}>
+                <div
+                  key={item.id}
+                  className={`pharmacy-table-row ${isMobile ? "pharmacy-table-row-mobile" : "pharmacy-table-row-desktop"} ${editingItem?.id === item.id ? "pharmacy-table-row-editing" : ""}`}
+                >
                   {editingItem?.id === item.id ? (
-                    <div className="edit-form-container" style={{ gridColumn: '1 / -1', display: 'contents' }}>
-                      <div style={{ gridColumn: '1' }}>
+                    <div className="edit-form-container pharmacy-table-edit-grid">
+                      <div className="pharmacy-edit-field pharmacy-edit-field-name">
                         <input
                           type="text"
-                          className="fm-input"
+                          className="fm-input pharmacy-edit-input"
                           value={editingItem.name}
                           onChange={(e) => setEditingItem({ ...editingItem, name: e.target.value })}
-                          style={{ 
-                            margin: 0, 
-                            fontSize: "0.9rem",
-                            border: "2px solid #10b981",
-                            boxShadow: "0 0 0 3px rgba(16, 185, 129, 0.1)"
-                          }}
                         />
                       </div>
-                      <div style={{ gridColumn: '2' }}>
+                      <div className="pharmacy-edit-field pharmacy-edit-field-quantity">
                         <input
                           type="number"
-                          className="fm-input"
+                          className="fm-input pharmacy-edit-input"
                           value={editingItem.quantity}
                           onChange={(e) => setEditingItem({ ...editingItem, quantity: parseInt(e.target.value, 10) })}
-                          style={{ 
-                            margin: 0, 
-                            fontSize: "0.9rem",
-                            border: "2px solid #10b981",
-                            boxShadow: "0 0 0 3px rgba(16, 185, 129, 0.1)"
-                          }}
                           min="1"
                         />
                       </div>
-                      <div style={{ gridColumn: '3' }}>
+                      <div className="pharmacy-edit-field pharmacy-edit-field-price">
                         <input
                           type="number"
-                          className="fm-input"
+                          className="fm-input pharmacy-edit-input"
                           value={editingItem.price}
                           onChange={(e) => setEditingItem({ ...editingItem, price: parseFloat(e.target.value) })}
-                          style={{ 
-                            margin: 0, 
-                            fontSize: "0.9rem",
-                            border: "2px solid #10b981",
-                            boxShadow: "0 0 0 3px rgba(16, 185, 129, 0.1)"
-                          }}
                           min="0"
                           step="0.01"
                         />
                       </div>
-                      <div style={{ 
-                        display: 'flex', 
-                        gap: '10px', 
-                        justifyContent: 'flex-end', 
-                        alignItems: 'center', 
-                        gridColumn: '4'
-                      }}>
-                        <button 
-                          type="button" 
-                          className="fm-search-btn" 
+                      <div className="pharmacy-table-edit-actions">
+                        <button
+                          type="button"
+                          className="fm-search-btn pharmacy-table-save-button"
                           onClick={saveEditing}
-                          style={{ 
-                            padding: "8px 16px",
-                            fontSize: "0.8rem",
-                            backgroundColor: '#10b981',
-                            minHeight: "auto",
-                            width: isMobile ? '100%' : 'auto'
-                          }}
                         >
                           <FaSave size={14} />
                           Save
                         </button>
-                        <button 
-                          type="button" 
+                        <button
+                          type="button"
+                          className="pharmacy-table-cancel-button"
                           onClick={cancelEditing}
-                          style={{ 
-                            padding: "8px 16px",
-                            fontSize: "0.8rem",
-                            backgroundColor: "#f8fafc",
-                            color: "#6b7280",
-                            border: "1px solid #d1d5db",
-                            borderRadius: "6px",
-                            cursor: "pointer",
-                            width: isMobile ? '100%' : 'auto'
-                          }}
                         >
                           Cancel
                         </button>
@@ -567,88 +486,33 @@ export default function PharmacyPage() {
                     <>
                       {isMobile ? (
                         <div>
-                          <div style={{ 
-                            fontWeight: "600", 
-                            color: "#00664c",
-                            fontSize: "1rem",
-                            marginBottom: "8px",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "8px"
-                          }}>
-                            <FaCapsules style={{ color: "#667eea" }} />
+                          <div className="pharmacy-table-mobile-title">
+                            <FaCapsules className="pharmacy-table-mobile-icon" />
                             {item.name}
                           </div>
-                          <div style={{ 
-                            display: "flex", 
-                            justifyContent: "space-between", 
-                            alignItems: "center",
-                            marginBottom: "12px"
-                          }}>
-                            <div style={{ 
-                              color: "#00664c", 
-                              fontWeight: "600",
-                              fontSize: "0.9rem",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "4px"
-                            }}>
+                          <div className="pharmacy-table-mobile-summary">
+                            <div className="pharmacy-table-mobile-meta">
                               <FaSortNumericUp size={12} />
                               {item.quantity} units
                             </div>
-                            <div style={{ 
-                              color: "#00664c", 
-                              fontWeight: "600",
-                              fontSize: "0.9rem",
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "4px"
-                            }}>
+                            <div className="pharmacy-table-mobile-meta">
                               <FaDollarSign size={12} />
                               ₹{item.price.toFixed(2)}
                             </div>
                           </div>
-                          <div style={{ 
-                            display: 'flex', 
-                            gap: '8px', 
-                            justifyContent: 'flex-end' 
-                          }}>
-                            <button 
-                              type="button" 
+                          <div className="pharmacy-table-actions">
+                            <button
+                              type="button"
                               onClick={() => startEditing(item)}
-                              style={{ 
-                                padding: "8px 12px",
-                                backgroundColor: "#dbeafe",
-                                color: "#1d4ed8",
-                                border: "1px solid #bfdbfe",
-                                borderRadius: "6px",
-                                cursor: "pointer",
-                                fontSize: "0.8rem",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "4px",
-                                transition: "all 0.2s ease"
-                              }}
+                              className="pharmacy-table-action-button pharmacy-table-action-button-edit"
                             >
                               <FaEdit size={12} />
                               Edit
                             </button>
-                            <button 
-                              type="button" 
+                            <button
+                              type="button"
                               onClick={() => deleteItem(item.id)}
-                              style={{ 
-                                padding: "8px 12px",
-                                backgroundColor: "#fee2e2",
-                                color: "#dc2626",
-                                border: "1px solid #fecaca",
-                                borderRadius: "6px",
-                                cursor: "pointer",
-                                fontSize: "0.8rem",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "4px",
-                                transition: "all 0.2s ease"
-                              }}
+                              className="pharmacy-table-action-button pharmacy-table-action-button-delete"
                             >
                               <FaTrash size={12} />
                               Delete
@@ -657,81 +521,22 @@ export default function PharmacyPage() {
                         </div>
                       ) : (
                         <>
-                          <div style={{ 
-                            fontWeight: "600", 
-                            color: "#00664c",
-                            fontSize: "0.95rem",
-                            wordBreak: "break-word"
-                          }}>
-                            {item.name}
-                          </div>
-                          <div style={{ 
-                            color: "#00664c", 
-                            fontWeight: "600",
-                            fontSize: "0.95rem"
-                          }}>
-                            {item.quantity} units
-                          </div>
-                          <div style={{ 
-                            color: "#00664c", 
-                            fontWeight: "600",
-                            fontSize: "0.95rem"
-                          }}>
-                            ₹{item.price.toFixed(2)}
-                          </div>
-                          <div style={{ 
-                            display: 'flex', 
-                            gap: '8px', 
-                            justifyContent: 'flex-end' 
-                          }}>
-                            <button 
-                              type="button" 
+                          <div className="pharmacy-table-cell pharmacy-table-cell-name">{item.name}</div>
+                          <div className="pharmacy-table-cell">{item.quantity} units</div>
+                          <div className="pharmacy-table-cell">₹{item.price.toFixed(2)}</div>
+                          <div className="pharmacy-table-actions">
+                            <button
+                              type="button"
                               onClick={() => startEditing(item)}
-                              style={{ 
-                                padding: "8px 12px",
-                                backgroundColor: "#dbeeeaff",
-                                color: "#1a9e87",
-                                border: "1px solid #a1e7d6ff",
-                                borderRadius: "6px",
-                                cursor: "pointer",
-                                fontSize: "0.8rem",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "4px",
-                                transition: "all 0.2s ease"
-                              }}
-                              onMouseEnter={(e) => {
-                                e.target.style.backgroundColor = "#bfdbfe";
-                              }}
-                              onMouseLeave={(e) => {
-                                e.target.style.backgroundColor = "#dbeafe";
-                              }}
+                              className="pharmacy-table-action-button pharmacy-table-action-button-edit"
                             >
                               <FaEdit size={12} />
                               Edit
                             </button>
-                            <button 
-                              type="button" 
+                            <button
+                              type="button"
                               onClick={() => deleteItem(item.id)}
-                              style={{ 
-                                padding: "8px 12px",
-                                backgroundColor: "#fee2e2",
-                                color: "#dc2626",
-                                border: "1px solid #fecaca",
-                                borderRadius: "6px",
-                                cursor: "pointer",
-                                fontSize: "0.8rem",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "4px",
-                                transition: "all 0.2s ease"
-                              }}
-                              onMouseEnter={(e) => {
-                                e.target.style.backgroundColor = "#fecaca";
-                              }}
-                              onMouseLeave={(e) => {
-                                e.target.style.backgroundColor = "#fee2e2";
-                              }}
+                              className="pharmacy-table-action-button pharmacy-table-action-button-delete"
                             >
                               <FaTrash size={12} />
                               Delete
@@ -746,12 +551,6 @@ export default function PharmacyPage() {
             )}
           </div>
         </div>
-        <style>{`
-          @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-          }
-        `}</style>
       </main>
 
       <footer className="fm-footer">

--- a/memory.md
+++ b/memory.md
@@ -114,6 +114,11 @@ Connects patients with nearby pharmacies to check medication stock. Features use
 - Invalid input returns `400 Bad Request` with structured error array: `{ error, details: [{ field, message }] }`.
 - Valid registrations proceed unchanged through existing flow.
 
+### PharmacyPage Styling Refactor (June 2026)
+- Inline styling in `frontend/src/components/PharmacyPage.jsx` was moved into `frontend/src/components/PharmacyPage.css`.
+- The refactor replaced inline `style={{ ... }}` props with semantic class-based styling for form icons, table layout, loading/empty states, and edit/action buttons.
+- Layout, spacing, and responsive behavior were preserved while making the component easier to maintain.
+
 ## 🔗 Related Documentation
 
 - [agent.md](agent.md) - Strict behavioral rules for AI Agents.


### PR DESCRIPTION
Closes # 50

##📝 Changes Made

- Moved all inline styles from the pharmacy page component into the existing stylesheet.
- Replaced inline style props with semantic CSS classes for form icons, table layout, loading/empty states, and edit/action  buttons.
- Preserved the existing UI layout and responsiveness while improving maintainability and readability.

## 📚 Documentation Changes

- [x] No documentation changes needed

## ⚙️ Environment Variables

- [x] No new environment variables needed

## ✅ Testing Checklist

- [x] I have read the CONTRIBUTING.md guide.
- [x] I am assigned to the linked issue(s).
- [x] I have tested these changes locally.
- [x] I have run the relevant checks and verified the application works as expected.
- [x] My code uses standard LF (Unix-style) line endings.
- [x] My commit messages follow the Conventional Commits format.