### PR TITLE
Fix/56 pharmacy details fetch

### DIFF
--- a/backend/controllers/drugController.js
+++ b/backend/controllers/drugController.js
@@ -1,5 +1,6 @@
 import Medicine from "../models/medicine.js";
 import Stock from "../models/stock.js";
+import Pharmacy from '../models/pharmacy.js';
 
 export const searchDrugs = async (req,res) => {
     const medicine_name = req.query.name;
@@ -18,8 +19,8 @@ export const searchDrugs = async (req,res) => {
       // Find all pharmacies that have the medicine
       const stocks = await Stock.find({
         "medications.medicine_id": drugs[0]._id,
-      });
-    
+      }).populate('pharmacy_id','user_name address city state pincode latitude longitude phone_number closing_hours location_url');
+      
       if (stocks.length === 0) {
         return res.json({ message: "No stock found" });
       }
@@ -30,9 +31,10 @@ export const searchDrugs = async (req,res) => {
           (m) => m.medicine_id.toString() === drugs[0]._id.toString()
         );
         return {
-          pharmacy_id: stock.pharmacy_id,
+          pharmacy: stock.pharmacy_id,
           stock: medicationEntry,
         };
       });
+      
       res.json({ drug: drugs[0], stocks: result });
 };

--- a/backend/controllers/drugController.js
+++ b/backend/controllers/drugController.js
@@ -1,6 +1,6 @@
 import Medicine from "../models/medicine.js";
 import Stock from "../models/stock.js";
-import Pharmacy from '../models/pharmacy.js';
+
 
 export const searchDrugs = async (req,res) => {
     const medicine_name = req.query.name;

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -349,7 +349,7 @@ describe("PharmaNear Full Integration Test Suite", () => {
       expect(response.body.drug.name).toBe("Amoxicillin Test");
       expect(response.body).toHaveProperty("stocks");
       expect(response.body.stocks).toHaveLength(1);
-      expect(response.body.stocks[0].pharmacy_id).toBe(pharmacyId);
+      expect(response.body.stocks[0].pharmacy._id.toString()).toBe(pharmacyId);
       expect(response.body.stocks[0].stock.quantity).toBe(45);
     });
 

--- a/frontend/src/components/MapPage.jsx
+++ b/frontend/src/components/MapPage.jsx
@@ -125,51 +125,42 @@ export default function MapPage() {
 
     useEffect(() => {
         if (medicineData?.stocks?.length > 0) {
-            const fetchPharmacyDetails = async () => {
-                try {
-                    const pharmacyList = await Promise.all(
-                        medicineData.stocks.map(async (item) => {
-                            try {
-                                const response = await fetch(
-                                    `${BACKEND_URL}/api/pharmacy/details?pharmacy_id=${item.pharmacy_id}`
-                                );
-                                const pharmacy = await response.json();
-                                const addressParts = [];
-                                if (pharmacy?.address) addressParts.push(pharmacy.address);
-                                if (pharmacy?.city) addressParts.push(pharmacy.city);
-                                if (pharmacy?.state) addressParts.push(pharmacy.state);
-                                if (pharmacy?.pincode) addressParts.push(pharmacy.pincode);
-                                const fullAddress = addressParts.length > 0 ? addressParts.join(', ') : "Address not available";
+            try {
+              const pharmacyList = medicineData.stocks.map((item) => {
+                const pharmacy = item.pharmacy;
 
-                                return {
-                                    id: pharmacy?._id || `unknown-${Math.random()}`,
-                                    name: pharmacy?.user_name || "Unknown Pharmacy",
-                                    address: fullAddress,
-                                    closing: pharmacy?.closing_hours || "Not specified",
-                                    phone: pharmacy?.phone_number || "Not available",
-                                    lat: pharmacy?.latitude != null ? pharmacy.latitude : userLocation.lat + Math.random() * 0.01,
-                                    lng: pharmacy?.longitude != null ? pharmacy.longitude : userLocation.lng + Math.random() * 0.01,
-                                    location_url: pharmacy?.location_url || null,
-                                    stock: item?.stock?.quantity > 0 ? "in-stock" : "out-of-stock",
-                                    price: item?.stock?.price || 0,
-                                    quantity: item?.stock?.quantity || 0,
-                                };
-                            } catch (error) {
-                                console.error("Error fetching pharmacy details:", error);
-                                return null;
-                            }
-                        })
-                    );
-
-                    const validPharmacies = pharmacyList.filter(p => p !== null);
-                    setPharmacies(validPharmacies.length ? validPharmacies : fallbackPharmacies);
-                } catch (error) {
-                    console.error("Error processing pharmacy data:", error);
-                    setPharmacies(fallbackPharmacies);
+                if(!pharmacy || typeof pharmacy === 'string') {
+                  return null
                 }
-            };
 
-            fetchPharmacyDetails();
+                const addressParts = []
+                if(pharmacy.address) addressParts.push(pharmacy.address);
+                if(pharmacy.city) addressParts.push(pharmacy.city);
+                if(pharmacy.state) addressParts.push(pharmacy.state);
+                if(pharmacy.pincode) addressParts.push(pharmacy.pincode);
+                const fullAddress = addressParts.length > 0 ? addressParts.join(', ') : "Address not available";
+                
+                return {
+                    id: pharmacy?._id || `unknown-${Math.random()}`,
+                    name: pharmacy?.user_name || "Unknown Pharmacy",
+                    address: fullAddress,
+                    closing: pharmacy?.closing_hours || "Not specified",
+                    phone: pharmacy?.phone_number || "Not available",
+                    lat: pharmacy?.latitude != null ? pharmacy.latitude : userLocation.lat + Math.random() * 0.01,
+                    lng: pharmacy?.longitude != null ? pharmacy.longitude : userLocation.lng + Math.random() * 0.01,
+                    location_url: pharmacy?.location_url || null,
+                    stock: item?.stock?.quantity > 0 ? "in-stock" : "out-of-stock",
+                    price: item?.stock?.price || 0,
+                    quantity: item?.stock?.quantity || 0,
+                };
+              });
+
+              const validPharmacies = pharmacyList.filter(p => p !== null);
+              setPharmacies(validPharmacies.length ? validPharmacies : fallbackPharmacies);
+            }
+            catch(error) {
+              return null
+            }
         } else {
             setPharmacies(fallbackPharmacies);
         }

--- a/frontend/src/components/MapPage.jsx
+++ b/frontend/src/components/MapPage.jsx
@@ -159,6 +159,7 @@ export default function MapPage() {
               setPharmacies(validPharmacies.length ? validPharmacies : fallbackPharmacies);
             }
             catch(error) {
+              console.error("Error fetching pharmacy details:", error);
               return null
             }
         } else {

--- a/memory.md
+++ b/memory.md
@@ -130,6 +130,11 @@ Connects patients with nearby pharmacies to check medication stock. Features use
 - AI coding agents supporting the customizations framework will automatically parse and load the constraints defined in this file (e.g. Conventional Commit PR naming, security protocols, terse responses) directly into their system prompt for all turns.
 - Keeps agent behavior aligned with repository guidelines without manual intervention.
 
+### Optimized Drug Search API N+1 Fix (June 2026)
+- Updated `GET /api/drugs` in `drugController.js` to use Mongoose `.populate()`. This returns full pharmacy details directly in the search response, eliminating the need for the frontend to fire multiple `/api/pharmacy/details` requests.
+### API Response Rename (June 2026)
+- For semantic clarity, the populated pharmacy object in the `/api/drugs` response was renamed from `pharmacy_id` to `pharmacy`.
+
 ## 🔗 Related Documentation
 
 - [.agents/AGENTS.md](file:///d:/git%20folder/PharmaNear/.agents/AGENTS.md) - Auto-loading workspace customization rules and behavior guidelines for AI agents.


### PR DESCRIPTION

## 🔗 Linked Issues

Closes #56 

## 📝 Changes Made
- **Backend (`backend/controllers/drugController.js`)**: Updated the `searchDrugs` function to use Mongoose `.populate()` to fetch pharmacy details (name, address, coordinates, etc.) directly in the initial query. Renamed the response key from `pharmacy_id` to `pharmacy` for semantic clarity.
- **Frontend (`frontend/src/components/MapPage.jsx`)**: Removed the N+1 query loop that fired multiple `/api/pharmacy/details` requests. The component now reads the populated pharmacy data directly from the `/api/drugs` response. Added robust error handling (`try/catch` and `return null`) for edge cases.
- **Documentation (`memory.md`)**: Documented the architectural decision to use `.populate()` and the API response key rename for future contributors.

## 📸 Screenshots
N/A
*If your changes affect the UI, please include before/after screenshots.*

| Before | After |
| ------ | ----- |
|  N/A      |  N/A     |

## 📚 Documentation Changes
<!-- If your changes require documentation updates, please list them here. -->
*If your changes affect the codebase, API, or user-facing features, documentation updates are required.*
- [ ] No documentation changes needed
- [ ] Updated README.md
- [ ] Updated CONTRIBUTING.md
- [ ] Updated inline code comments
- [x] Other: Updated `memory.md` with the new API response structure and N+1 query resolution.

## ⚙️ Environment Variables
<!-- If any new environment variables need to be added to the project due to the merging of this PR, please list them out below and ensure they are added to .env.example templates. -->
- [x] No new environment variables needed
- [ ] Yes, new environment variables are required (please list keys and description below):
  - Key(s): 

## ✅ Testing Checklist
<!-- Please review and check the applicable items. -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] I am assigned to the linked issue(s).
- [x] I have tested these changes locally.
- [x] I have run `pnpm run test` and all tests pass.
- [x] My code uses standard LF (Unix-style) line endings.
- [x] My commit messages follow the Conventional Commits format.
