### PR TITLE
perf: implement code-splitting and user-intent prefetching for MapPage

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,3 +65,11 @@ body {
     gap: 10px 15px;
   }
 }
+
+.loading-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-size: 1.2rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,11 +21,10 @@ const PharmacyDashboard = React.lazy(() => import('./components/PharmacyDashboar
 
 // A clean loading fallback component
 const LoadingSpinner = () => (
-  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', fontSize: '1.2rem' }}>
+  <div className="loading-spinner-container">
     Loading...
   </div>
 );
-
 function App() {
   return (
     <BrowserRouter>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,39 +1,54 @@
+import React, { Suspense } from 'react';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import './App.css';
+
+// Synchronous imports for lightweight landing pages
+import FirstPage from './components/FirstPage.jsx';
+import PharmacyPage from './components/PharmacyPage.jsx';
+import LoginPage from './components/LoginPage.jsx';
+import SignupPage from './components/SignupPage.jsx';
 import AboutUs from './components/AboutUs.jsx';
 import Services from './components/Services.jsx';
 import Contact from './components/Contact.jsx';
 import PrivacyPolicy from './components/PrivacyPolicy.jsx';
 import TermsOfService from './components/TermsOfService.jsx';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import './App.css';
-import FirstPage from './components/FirstPage.jsx';
-import MapPage from './components/MapPage.jsx';
-import PharmacyAdmin from './components/PharmacyAdmin.jsx';
-import PharmacyPage from './components/PharmacyPage.jsx';
-import PharmacyDashboard from './components/PharmacyDashboard.jsx';
-import LoginPage from './components/LoginPage.jsx';
-import SignupPage from './components/SignupPage.jsx';
 import NotFoundPage from './components/NotFoundPage.jsx';
+
+// LAZY LOADED IMPORTS (Splits heavy dependencies like Leaflet into separate chunks)
+const MapPage = React.lazy(() => import('./components/MapPage.jsx'));
+const PharmacyAdmin = React.lazy(() => import('./components/PharmacyAdmin.jsx'));
+const PharmacyDashboard = React.lazy(() => import('./components/PharmacyDashboard.jsx'));
+
+// A clean loading fallback component
+const LoadingSpinner = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', fontSize: '1.2rem' }}>
+    Loading...
+  </div>
+);
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<FirstPage />} />
-        <Route path="/mappage" element={<MapPage />} />
-        <Route path="/pharmacy" element={<PharmacyPage />} />
-        <Route path="/pharmacy/admin" element={<PharmacyAdmin />} />
-        <Route path="/pharmacy/dashboard" element={<PharmacyDashboard />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/signup" element={<SignupPage />} />
-       
-        <Route path="/about" element={<AboutUs />} />
-        <Route path="/services" element={<Services />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-        <Route path="/terms-of-service" element={<TermsOfService />} />
+      {/* Suspense boundary catches lazy loaded paths and shows a fallback while downloading the bundle */}
+      <Suspense fallback={<LoadingSpinner />}>
+        <Routes>
+          <Route path="/" element={<FirstPage />} />
+          <Route path="/mappage" element={<MapPage />} />
+          <Route path="/pharmacy" element={<PharmacyPage />} />
+          <Route path="/pharmacy/admin" element={<PharmacyAdmin />} />
+          <Route path="/pharmacy/dashboard" element={<PharmacyDashboard />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          
+          <Route path="/about" element={<AboutUs />} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
 
-         <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/FirstPage.jsx
+++ b/frontend/src/components/FirstPage.jsx
@@ -14,6 +14,13 @@ function FindMedicine() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
+  // PREFETCH PATTERN: Triggers browser to download MapPage code bundle in the background
+  const handlePrefetchMap = () => {
+    import("./MapPage.jsx")
+      .then(() => console.log("MapPage bundle prefetched successfully!"))
+      .catch((err) => console.error("Error prefetching MapPage bundle:", err));
+  };
+
   const getLocation = () => {
     return new Promise((resolve) => {
       if (navigator.geolocation) {
@@ -103,6 +110,7 @@ function FindMedicine() {
             placeholder="Search for medicines & health products"
             value={medicine}
             onChange={(e) => setMedicine(e.target.value)}
+            onFocus={handlePrefetchMap} // <--- Triggers optimization when user prepares to type
             className="fm-input with-icon"
           />
         </div>
@@ -128,6 +136,7 @@ function FindMedicine() {
               placeholder="Dosage/Strength"
               value={dosage}
               onChange={(e) => setDosage(e.target.value)}
+              onFocus={handlePrefetchMap} // <--- Also prefetch if they jump to dosage options first
               className="fm-input with-icon"
               style={{
                 width: "100%",

--- a/frontend/src/components/FirstPage.jsx
+++ b/frontend/src/components/FirstPage.jsx
@@ -15,10 +15,9 @@ function FindMedicine() {
   const [loading, setLoading] = useState(false);
 
   // PREFETCH PATTERN: Triggers browser to download MapPage code bundle in the background
+  // PREFETCH PATTERN: Triggers browser to download MapPage code bundle in the background
   const handlePrefetchMap = () => {
-    import("./MapPage.jsx")
-      .then(() => console.log("MapPage bundle prefetched successfully!"))
-      .catch((err) => console.error("Error prefetching MapPage bundle:", err));
+    import("./MapPage.jsx").catch(() => {});
   };
 
   const getLocation = () => {

--- a/memory.md
+++ b/memory.md
@@ -152,3 +152,8 @@ Connects patients with nearby pharmacies to check medication stock. Features use
 
 - [.agents/AGENTS.md](file:///d:/git%20folder/PharmaNear/.agents/AGENTS.md) - Auto-loading workspace customization rules and behavior guidelines for AI agents.
 - [README.md](file:///d:/git%20folder/PharmaNear/README.md) - Tech Stack, Getting Started guide, and folder structure.
+
+### Optimization: Frontend Code Splitting & Prefetching
+- Migrated core routes (`MapPage`, `PharmacyAdmin`, `PharmacyDashboard`) to asynchronous loading using `React.lazy()` to reduce initial bundle overhead.
+- Introduced `<Suspense>` wrapper with a full-screen loading placeholder.
+- Implemented an `onFocus` trigger on `FirstPage.jsx` inputs to selectively prefetch the heavy Leaflet bundle (`~708 kB`) in the background based on user intent.


### PR DESCRIPTION
## 🔗 Linked Issues
Closes #51

# 📝 Changes Made
- Migrated heavy pages (`MapPage`, `PharmacyAdmin`, and `PharmacyDashboard`) in `App.jsx` to load asynchronously using `React.lazy()`.
- Implemented a `<Suspense>` boundary wrapping the core application routes with a clean loading fallback element.
- Added a strategic user-intent prefetching mechanism (`handlePrefetchMap`) on `FirstPage.jsx` triggered by the search bar's `onFocus` event to download the map bundle silently in the background.
- Successfully reduced the initial core bundle size by isolating the heavy Leaflet and Leaflet Routing Machine dependencies into a separate split chunk (`MapPage-*.js` at ~708 kB).

## 📚 Documentation Changes
- [x] Updated inline code comments

## Screenshot:

<img width="872" height="488" alt="Screenshot 2026-06-28 184245" src="https://github.com/user-attachments/assets/5026eb44-a6e6-427e-94a2-4101fdc0ffca" />

## ⚙️ Environment Variables
- [x] No new environment variables needed

## ✅ Testing Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] I am assigned to the linked issue(s).
- [x] I have tested these changes locally.
- [x] My code uses standard LF (Unix-style) line endings.
- [x] My commit messages follow the Conventional Commits format.